### PR TITLE
optimized Dockerfile to use docker mutlti-stage build mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache git
 # Build project
 WORKDIR /go/src/github.com/backpulse/core
 COPY . .
-RUN dep ensure --vendor-only
+RUN dep ensure
 RUN go build -o main .
 
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:alpine AS binaryBuilder
 
 ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
 RUN chmod +x /usr/bin/dep
@@ -18,4 +18,9 @@ RUN dep ensure --vendor-only
 
 RUN go build -o main .
 
-CMD ["./main"]
+FROM alpine:latest
+WORKDIR /app/backpulse
+COPY --from=binaryBuilder /go/src/github.com/backpulse/core/main .
+
+EXPOSE 8000
+CMD ["/app/backpulse/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,18 @@
 FROM golang:alpine AS binaryBuilder
-
+# Install build deps
 ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
 RUN chmod +x /usr/bin/dep
-
 RUN apk add --no-cache git
-
-RUN mkdir /go/src/github.com/
-RUN mkdir /go/src/github.com/aureleoules
-RUN mkdir /go/src/github.com/backpulse/core
-
-ADD . /go/src/github.com/backpulse/core
-
-WORKDIR /go/src/github.com/backpulse/core 
-
-COPY Gopkg.toml Gopkg.lock ./
+# Build project
+WORKDIR /go/src/github.com/backpulse/core
+COPY . .
 RUN dep ensure --vendor-only
-
 RUN go build -o main .
 
 FROM alpine:latest
+# Copy target app from binaryBuilder stage
 WORKDIR /app/backpulse
 COPY --from=binaryBuilder /go/src/github.com/backpulse/core/main .
-
+# Configure Docker Container
 EXPOSE 8000
 CMD ["/app/backpulse/main"]


### PR DESCRIPTION
* docker multi-stage build mechanism can build a smallest image then direct build
* Dockerfile to support  multi-stage build since docker-ce version >=v17.06