### PR TITLE
use godotenv load env file into ENV as config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,20 @@
+# MongoDB server address (_mongodb://..._)
+MONGODB_URI=mongodb://mongodb:27017
+
+# MongoDB database name
+DATABASE=backpulse
+
+# A secret key to encrypt JWT
+# SECRET=?
+
+# A gmail address if you wish to send confirmation emails
+# GMAIL_ADDRESS=?
+
+# The password associated with the gmail address obviously
+# GMAIL_PASSWORD=?
+
+# Your Stripe Key if you wish to integrate Stripe
+# STRIPE_KEY=?
+
+# Your Google Cloud Storage Bucket's name to store user files (images, binaries, plain text...)
+# BUCKET_NAME=?

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor/
 .idea
 *.exe
+backpulse
 config.json
 backpulse.json
 google_credentials.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,11 @@ COPY hack/docker/nsswitch.conf /etc/nsswitch.conf
 # Copy target app from binaryBuilder stage
 WORKDIR /app/backpulse
 COPY hack/docker docker
+COPY .env ./
 COPY --from=binaryBuilder /go/src/github.com/backpulse/core/backpulse .
 
 # Finalize s6 configure
 RUN ./docker/finalize.sh
-
-# Configure Docker Container
-ENV MONGODB_URI mongodb://mongodb:27017
-ENV DATABASE backpulse
 
 # Configure Docker Container
 VOLUME ["/data"]

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ make build
 ## Docker Build&Run
 ```bash
 docker build -t <your-backpulse-tag> .
-docker run -d --links <mongodb-container>:mongodb <your-backpulse-tag>
+docker run -d --link <mongodb-container>:mongodb <your-backpulse-tag>
 ```
 or docker run in custom environment
 ```bash
 docker run -d \
-           --links <mongodb-container>:mongodb \
+           --link <mongodb-container>:mongodb \
            --env MONGODB_URI=mongodb://mongodb:27017 \
            --env DATABASE=backpulse \
            <your-backpulse-tag>

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.6.2
+	github.com/joho/godotenv v1.3.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1
 	github.com/rs/cors v1.6.0
 	github.com/sirupsen/logrus v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCO
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/hack/docker/s6/backpulse-serve/run
+++ b/hack/docker/s6/backpulse-serve/run
@@ -5,4 +5,4 @@ if test -f ./setup; then
 fi
 
 export USER=backpulse
-exec gosu $USER /app/backpulse/backpulse
+exec gosu $USER /app/backpulse/backpulse -env /app/backpulse/.env

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net/http"
 	"os"
@@ -8,11 +9,25 @@ import (
 	"github.com/backpulse/core/database"
 	"github.com/backpulse/core/routes"
 	"github.com/backpulse/core/utils"
+	"github.com/joho/godotenv"
 	"github.com/rs/cors"
 )
 
+var (
+	envFile string
+)
+
+func init() {
+	// env file and will load them into ENV for this process.
+	// will not overload value that defined in ENV had present.
+	flag.StringVar(&envFile, "env", ".env", "env config file")
+}
+
 func main() {
+	flag.Parse()
+
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	godotenv.Load(envFile)
 	config := utils.GetConfig()
 
 	database.Connect(config.URI, config.Database)


### PR DESCRIPTION
* use [godotenv](https://github.com/joho/godotenv) load env file info ENV, so we can use os.Getenv(...) get all the app's config. 
* use godotenv load env file into ENV but not overload value that had present in ENV,this is very friendly  for docker environment.We can define default app's config in .env file and load by godotenv, then run app by docker passed custom environment value use cmd like `docker run ... --env ...` 
* now config passer priority: config.json > ENV(system environment value) > .env file(load by godotenv)
* what about use .env as single config file for app? I think godotenv load .env file to ge all config is all enough that we need.
